### PR TITLE
fix: bug in function expiresToSeconds

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -13,7 +13,7 @@ function genRandomID(): string {
 const expiresToSeconds = (expires: Date) => {
     const now = new Date();
     const expiresDate = new Date(expires);
-    const secondsDelta = expiresDate.getSeconds() - now.getSeconds();
+    const secondsDelta = (expiresDate.getTime() - now.getTime())/1000;
     return secondsDelta < 0 ? 0 : secondsDelta;
 };
 


### PR DESCRIPTION
This function is expected to return the diff in seconds with respect to current time. However, using getSeconds produces incorrect outcome because it returns the current second of the provided datetime.